### PR TITLE
PR: Hanbin/groq ai summary

### DIFF
--- a/src/components/CompanyDetail/AISummary.tsx
+++ b/src/components/CompanyDetail/AISummary.tsx
@@ -18,7 +18,7 @@ const AISummary: React.FC<CompanyInfoProps> = ({ companyDetail }) => {
                 <p className="text-gray-700 leading-relaxed text-lg">{companyDetail?.aiSummary}</p>
             </div>
             <div className="mt-4 text-sm text-gray-500">
-                * Groq AI를 통해 생성된 요약입니다. 투자 결정의 참고용으로만 활용하세요.
+                * Groq AI를 통해 생성된 요약입니다. 참고용으로만 활용하세요.
             </div>
         </div>
     );

--- a/src/components/CompanyDetail/LoadingSpinner.tsx
+++ b/src/components/CompanyDetail/LoadingSpinner.tsx
@@ -2,16 +2,16 @@ import React from "react";
 
 const LoadingSpinner: React.FC = () => {
     return (
-            <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-                <div className="text-center">
-                    <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-                    <p className="text-gray-600">기업 정보를 분석하고 있습니다...</p>
-                    <p className="text-sm text-gray-500 mt-2">DART 공시정보, 뉴스, AI 요약을 수집 중</p>
-                </div>
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+            <div className="text-center">
+                <div className="w-16 h-16 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+                <p className="text-gray-600">기업 정보를 분석하고 있습니다...</p>
+                <p className="text-sm text-gray-500 mt-2">DART 공시정보, 뉴스, AI 요약을 수집 중</p>
             </div>
-        )
+        </div>
+    )
 }
 
-    
+
 
 export default LoadingSpinner;

--- a/src/data/companies.ts
+++ b/src/data/companies.ts
@@ -38,6 +38,14 @@ export interface CompanyDetail {
     news: Record<string, NewsItem[]>;
 }
 
+export interface SummaryOut {
+    id: number;
+    company_name: string;
+    summary_text: string;
+    created_at: string;    // ISO string
+    updated_at: string;    // ISO string
+}
+
 
 // 더미 기업 데이터
 export const dummyCompanies: Company[] = [

--- a/src/hooks/useCompanyDetail.ts
+++ b/src/hooks/useCompanyDetail.ts
@@ -76,15 +76,12 @@ export function useCompanyDetail(
                         netIncome: vals['당기순이익'],
                     })
                 );
-                console.log("재무 데이터:", financialData);
 
                 // 4) 뉴스 카테고리별 전체 호출
                 const newsRes = await axios.get<Record<string, NewsItem[]>>(
                     `${API_BASE_URL}/naver/news/all?company=${encodeURIComponent(found.name)}`
                 );
                 const newsMap = newsRes.data;
-                console.log("뉴스 데이터:", newsMap);
-
 
 
                 // 5) AI 요약

--- a/src/hooks/useCompanyDetail.ts
+++ b/src/hooks/useCompanyDetail.ts
@@ -30,10 +30,9 @@ export function useCompanyDetail(
         if (!companyName) return;
 
         const fetchAll = async () => {
+            setIsLoading(true);
+            setError(null);
             try {
-                setIsLoading(true);
-                setError(null);
-
                 // 1) 기본 회사 정보
                 const found = dummyCompanies.find((c) => c.name === companyName);
                 if (!found) throw new Error("해당 기업을 찾을 수 없습니다.");
@@ -61,8 +60,6 @@ export function useCompanyDetail(
                     industry,
                 };
 
-
-
                 // 3) 재무 데이터
                 const finRes = await axios.get<Record<string, any>>(
                     `${API_BASE_URL}/darts/getValues?code=${corpCode}`
@@ -83,7 +80,6 @@ export function useCompanyDetail(
                 );
                 const newsMap = newsRes.data;
 
-
                 // 5) AI 요약
                 const formattedNews: Record<string, NewsItem[]> = {};
                 Object.entries(newsMap).forEach(([category, articles]) => {
@@ -102,8 +98,6 @@ export function useCompanyDetail(
                     summaryReqBody
                 );
                 const aiSummary = aiSummaryRes.data.summary_text;
-                // const detailFromDummy = ({} as Record<string, CompanyDetail>)[companyName];
-                // const aiSummary = detailFromDummy?.aiSummary || '';
 
                 setCompanyDetail({
                     company: found,
@@ -119,7 +113,6 @@ export function useCompanyDetail(
                 setIsLoading(false);
             }
         };
-
         fetchAll();
     }, [companyName]);
 

--- a/src/hooks/useCompanyDetail.ts
+++ b/src/hooks/useCompanyDetail.ts
@@ -85,11 +85,20 @@ export function useCompanyDetail(
                 const newsMap = newsRes.data;
                 console.log("뉴스 데이터:", newsMap);
 
+
+
                 // 5) AI 요약
+                const formattedNews: Record<string, NewsItem[]> = {};
+                Object.entries(newsMap).forEach(([category, articles]) => {
+                    formattedNews[category] = articles.map((a) => ({
+                        ...a,
+                        pubDate: new Date(a.pubDate).toISOString(),
+                    }));
+                });
                 const summaryReqBody = {
-                    company_name: encodeURIComponent(found.name),
+                    company_name: found.name,
                     financial: financialData,
-                    news: newsMap
+                    news: formattedNews
                 };
                 const aiSummaryRes = await axios.post<SummaryOut>(
                     `${API_BASE_URL}/summary`,

--- a/src/hooks/useCompanyDetail.ts
+++ b/src/hooks/useCompanyDetail.ts
@@ -108,7 +108,7 @@ export function useCompanyDetail(
                 });
 
             } catch (err: any) {
-                setError(err.message || '데이터를 불러오는 중 오류가 발생했습니다.');
+                setError(err.response?.data?.detail || err.message);
             } finally {
                 setIsLoading(false);
             }


### PR DESCRIPTION
## Resolved #14 
>재무정보, 뉴스정보 포매팅
>훅 API URL `.env` 활용

## 추후 수정사항
> `기업페이지 → 대쉬보드 → 기업페이지` 순서로 이동할 때, 로딩스피너 후, 페이지 렌더링시 AI 분석 요약 텍스트가 `이전값 → 현재값` 으로 변경되며, 깜빡이는 현상 발생